### PR TITLE
[stretch] Added search functionality to search for graph breaks or its contents

### DIFF
--- a/app/api/registry/route.ts
+++ b/app/api/registry/route.ts
@@ -1,0 +1,7 @@
+import { getRegistry } from '@/app/lib/registry';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const registry = await getRegistry();
+  return NextResponse.json(registry);
+}

--- a/app/components/SearchBox.tsx
+++ b/app/components/SearchBox.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Fuse from 'fuse.js';
+
+type Entry = {
+  id: string;
+  Gb_type: string;
+  Explanation?: string;
+  Context?: string;
+};
+
+export function useFuzzyRegistrySearch(query: string) {
+  const [results, setResults] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    async function search() {
+      const res = await fetch('/api/registry');
+      const registry = await res.json();
+
+      const data = Object.entries(registry).map(([id, entries]: [string, any]) => ({
+        id,
+        ...entries[0],
+      }));
+
+      if (!query) {
+        setResults(data);
+        return;
+      }
+
+      const fuse = new Fuse(data, {
+        keys: ['id', 'Gb_type', 'Explanation', 'Context'],
+        threshold: 0.3,
+      });
+
+      const matches = fuse.search(query).map(res => res.item);
+      setResults(matches);
+    }
+
+    search();
+  }, [query]);
+
+  return results;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,13 @@
+'use client';
+
 import * as React from 'react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
-import { getRegistry } from '@/app/lib/registry';
+import { useFuzzyRegistrySearch } from '@/app/components/SearchBox';
 
-export const revalidate = 0;
-
-export default async function Home() {
-  const reg = await getRegistry();
+export default function Home() {
+  const [query, setQuery] = React.useState('');
+  const results = useFuzzyRegistrySearch(query);
 
   return (
     <main className="prose mx-auto p-6">
@@ -15,27 +16,30 @@ export default async function Home() {
         Below are all known graph breaks detected by&nbsp;Dynamo.
       </p>
 
+      <input
+        type="text"
+        placeholder="Search Graph Breaks"
+        className="px-3 py-2 border border-gray-300 rounded w-full max-w-xl mb-4"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+
       <ul>
-        {Object.entries(reg).map(([id, versions]) => {
-          const type = versions[0].Gb_type;
-          return (
-            <li key={id}>
-              <Link href={`/gb/${id}`}>{id}</Link> —{' '}
-              <ReactMarkdown
-                components={{
-                  // strip the implicit <p> wrapper inside <li>
-                  p: ({ node, ...props }) => <>{props.children}</>,
-                  // open any inline links in a new tab
-                  a: ({ node, ...props }) => (
-                    <a target="_blank" rel="noopener noreferrer" {...props} />
-                  ),
-                }}
-              >
-                {type}
-              </ReactMarkdown>
-            </li>
-          );
-        })}
+        {results.map(({ id, Gb_type }) => (
+          <li key={id}>
+            <Link href={`/gb/${id}`}>{id}</Link> —{' '}
+            <ReactMarkdown
+              components={{
+                p: ({ node, ...props }) => <>{props.children}</>,
+                a: ({ node, ...props }) => (
+                  <a target="_blank" rel="noopener noreferrer" {...props} />
+                ),
+              }}
+            >
+              {Gb_type}
+            </ReactMarkdown>
+          </li>
+        ))}
       </ul>
     </main>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mdx-js/loader": "3.1.0",
         "@next/mdx": "14.1.0",
+        "fuse.js": "^7.1.0",
         "next": "^15.3.3",
         "next-mdx-remote": "4.4.1",
         "react": "18.2.0",
@@ -1194,6 +1195,15 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mdx-js/loader": "3.1.0",
     "@next/mdx": "14.1.0",
+    "fuse.js": "^7.1.0",
     "next": "^15.3.3",
     "next-mdx-remote": "4.4.1",
     "react": "18.2.0",


### PR DESCRIPTION

https://github.com/user-attachments/assets/0d280df6-46c9-442b-bcea-c8e032080fc5


I added a search box on the main webpage, where you can search for a specific graph break, or even a specific context, gb_type, hints, additional info and it will show you what gb_type is associated with it. Note: At some point, I'll add a back button on the GBID webpages so users can go back to the main page.