### PR TITLE
Fix: Baseurl for test deployment to include full path

### DIFF
--- a/generate-site.js
+++ b/generate-site.js
@@ -32,7 +32,7 @@ description: A registry of PyTorch Dynamo graph breaks.
 
 # Base URL for the site
 # This is crucial for correct linking on GitHub Pages
-baseurl: "/test-docs-site" # Adjust this based on your actual GitHub Pages path
+baseurl: "/test-docs-site/docs/repo/compile-graph-break" # Adjust this based on your actual GitHub Pages path
 
 # Build settings
 theme: jekyll-theme-minimal # Or any other Jekyll theme you prefer


### PR DESCRIPTION
Fixed to original deployment yml file and updated path url to redirect to correct path for testing purposes